### PR TITLE
Allow the libev on system to be used instead of the embedded libev

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,8 @@
 ACLOCAL_AMFLAGS = -I m4 -I libmissing/m4
-SUBDIRS = docs libev libmissing m4 plugins src
+SUBDIRS = docs libmissing m4 plugins src
+if EMBEDDED_LIBEV
+SUBDIRS += libev
+endif
 
 EXTRA_DIST = AUTHORS COPYING HACKING.README INSTALL NEWS README \
              selinux/prelude-manager.te \

--- a/configure.in
+++ b/configure.in
@@ -197,18 +197,38 @@ fi
 
 
 dnl ********************************************************
-dnl * Configure embedded libev                             *
+dnl * Check for libev                                      *
 dnl ********************************************************
 
-AC_DEFINE_UNQUOTED(EV_USE_INOTIFY, 0, Disable unused libev inotify backend)
-AC_DEFINE_UNQUOTED(EV_PERIODIC_ENABLE, 0, Disable unused libev periodic timers)
-AC_DEFINE_UNQUOTED(EV_STAT_ENABLE, 0, Disable unused libev stat watchers)
-AC_DEFINE_UNQUOTED(EV_IDLE_ENABLE, 0, Disable unused libev idle watchers)
-AC_DEFINE_UNQUOTED(EV_FORK_ENABLE, 0, Disable unused libev fork watchers)
-AC_DEFINE_UNQUOTED(EV_EMBED_ENABLE, 0, Disable unused libev embed watchers)
+dnl Determine whether to use the embedded libev or the system libev
+AC_ARG_WITH([system-libev],
+	AC_HELP_STRING([--with-system-libev],
+		[Use the libev available on the system instead of the embedded libev]))
 
-m4_include([libev/libev.m4])
+if test x$with_system_libev = xyes; then
+	dnl Use the libev available on the system
+	PKG_CHECK_MODULES([LIBEV], [libev])
 
+	AC_CHECK_HEADER([ev.h], ,
+		AC_MSG_ERROR([libev development headers are required to build libprelude-manager]))
+else
+	dnl Configure and use embedded libev
+	AC_DEFINE_UNQUOTED(EV_USE_INOTIFY, 0, Disable unused libev inotify backend)
+	AC_DEFINE_UNQUOTED(EV_PERIODIC_ENABLE, 0, Disable unused libev periodic timers)
+	AC_DEFINE_UNQUOTED(EV_STAT_ENABLE, 0, Disable unused libev stat watchers)
+	AC_DEFINE_UNQUOTED(EV_IDLE_ENABLE, 0, Disable unused libev idle watchers)
+	AC_DEFINE_UNQUOTED(EV_FORK_ENABLE, 0, Disable unused libev fork watchers)
+	AC_DEFINE_UNQUOTED(EV_EMBED_ENABLE, 0, Disable unused libev embed watchers)
+
+	m4_include([libev/libev.m4])
+
+	LIBEV_CFLAGS="-I\$(top_srcdir)/libev"
+	LIBEV_LIBS="\$(top_builddir)/libev/libev.la"
+	AC_SUBST([LIBEV_CFLAGS])
+	AC_SUBST([LIBEV_LIBS])
+fi
+
+AM_CONDITIONAL([EMBEDDED_LIBEV], [test x$with_system_libev != xyes])
 
 
 dnl **************************************************
@@ -335,7 +355,6 @@ Makefile
 docs/Makefile
 docs/manpages/Makefile
 
-libev/Makefile
 libmissing/Makefile
 libmissing/tests/Makefile
 
@@ -362,6 +381,11 @@ plugins/reports/smtp/Makefile
 plugins/reports/textmod/Makefile
 plugins/reports/xmlmod/Makefile
 ])
+if test "x$with_system_libev" != "xyes"; then
+	AC_CONFIG_FILES([
+		libev/Makefile
+	])
+fi
 AC_OUTPUT
 
 echo
@@ -370,3 +394,4 @@ echo "    - TCP wrapper support    : $with_libwrap";
 echo "    - XML plugin support     : $enable_xmlmod";
 echo "    - GeoIP support          : $enable_libmaxminddb";
 echo "    - Database plugin support: $enable_libpreludedb";
+echo "    - Use system libev       : $with_system_libev";

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,10 +1,10 @@
 SUBDIRS = include
 
-AM_CPPFLAGS = -I$(srcdir)/include/ -I$(top_srcdir)/libmissing -I$(top_srcdir)/libev @LIBPRELUDE_CFLAGS@ @LIBGNUTLS_CFLAGS@
+AM_CPPFLAGS = -I$(srcdir)/include/ -I$(top_srcdir)/libmissing @LIBEV_CFLAGS@ @LIBPRELUDE_CFLAGS@ @LIBGNUTLS_CFLAGS@
 AM_CFLAGS = @PRELUDE_MANAGER_CFLAGS@ @GLOBAL_CFLAGS@
 
 bin_PROGRAMS = prelude-manager
-prelude_manager_LDADD = @LIBPRELUDE_LIBS@ @LIBWRAP_LIBS@ $(top_builddir)/libev/libev.la \
+prelude_manager_LDADD = @LIBPRELUDE_LIBS@ @LIBWRAP_LIBS@ @LIBEV_LIBS@	\
 			$(top_builddir)/libmissing/libmissing.la 	\
 			$(GETADDRINFOLIB) 				\
 			$(HOSTENTLIB)					\


### PR DESCRIPTION
Provide a configure option '--with-system-libev' which uses the libev
available on the host system instead of using the embedded one
available in the source tree.
